### PR TITLE
Add support for "text" format in saveScreen

### DIFF
--- a/p3270/p3270.py
+++ b/p3270/p3270.py
@@ -308,12 +308,16 @@ class P3270Client():
 
     def saveScreen(self, fileName='screen', dataType='html'):
         """ Save the current screen in the form of an HTML file.
+            Other types supported: rtf,txt
         """
         if fileName and self.conf.screensDir:
             fileName = os.path.join(self.conf.screensDir, fileName)
         if dataType == 'html' or dataType == 'rtf':
             logger.info("Save an '{}' screen to file [{}]".format(dataType, fileName))
             return self.s3270.do('PrintText({}, {})'.format(dataType, fileName))
+        if dataType == 'txt':
+            logger.info("Save an '{}' screen to file [{}]".format(dataType, fileName))
+            return self.s3270.do('PrintText(file, {})'.format(fileName))
         else:
             logger.error("Specified data type '{}' is invalid".format(dataType))
             return False


### PR DESCRIPTION

s3270 supports saving to file in plain-text format, in face if no type is specified that's what it defaults too.


The current implementation defaults to 'html' and allows saving as rtf, but it did not support the default method (by not defining any type).

This PR adds support for this.

Source: https://x3270.miraheze.org/wiki/PrintText()_action

Based on ^ if we send the command `PrintText(file,/tmp/snapshot.txt)` plain-text is used.

My proposal is to allow consumers of the library to send "txt" in dataType avoid changing the implementation much, so html is still default.